### PR TITLE
update decorator to not create decorated functions per request

### DIFF
--- a/rest_framework_condition/decorators.py
+++ b/rest_framework_condition/decorators.py
@@ -1,36 +1,90 @@
 import functools
-from django.views.decorators.http import condition as django_condition
+import warnings
+
+from calendar import timegm
+
+from django.utils.cache import get_conditional_response
+from django.utils.http import http_date, quote_etag
 
 
-def condition(etag_func=None, last_modified_func=None):
+def condition(etag_func=None, last_modified_func=None, use_self=False):
     """
-    Decorator to support conditional retrieval (or change)
-    for a Django Rest Framework's ViewSet.
+    Decorator to support conditional retrieval (or change) for a Django Rest
+    Framework's ViewSet.
 
-    It calls Django's original decorator but pass correct request object to it.
-    Django's original decorator doesn't work with DRF request object.
+    This decorator emulates Django's original decorator by wrapping the
+    underlying functionality where possible but handles the Django Rest
+    Framework request object.
+
+    See: django.views.decorators.http.condition
     """
+
+    if not use_self:
+        warnings.warn(
+            'The etag_func and last_modified_func should accept a "self" '
+            'argument which matches how Django Rest Framework calls '
+            'view/viewset methods.\n\n'
+            'After updating the handlers pass "use_self" to the condition '
+            'decorator to enable the future functionality and silence this '
+            'warning.',
+            DeprecationWarning)
+
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(obj_self, request, *args, **kwargs):
-            drf_request = request
-            wsgi_request = request._request
+        def wrapper(self, request, *args, **kwargs):
+            if etag_func:
+                if use_self:
+                    etag = etag_func(self, request, *args, **kwargs)
+                else:
+                    etag = etag_func(request, *args, **kwargs)
 
-            def patched_viewset_method(*_args, **_kwargs):
-                """Call original viewset method with correct type of request"""
-                return func(obj_self, drf_request, *args, **kwargs)
+                # The value from etag_func() could be quoted or unquoted.
+                if etag:
+                    etag = quote_etag(etag)
+            else:
+                etag = None
 
-            django_decorator = django_condition(etag_func, last_modified_func)
-            decorated_viewset_method = django_decorator(patched_viewset_method)
-            return decorated_viewset_method(wsgi_request, *args, **kwargs)
+            if last_modified_func:
+                if use_self:
+                    last_modified = last_modified_func(
+                        self, request, *args, **kwargs)
+                else:
+                    last_modified = last_modified_func(
+                        request, *args, **kwargs)
+
+                if last_modified:
+                    last_modified = timegm(last_modified.utctimetuple())
+            else:
+                last_modified = None
+
+            # pass the wrapped WSGI request for Django
+            response = get_conditional_response(
+                request._request,
+                etag=etag,
+                last_modified=last_modified,
+            )
+
+            if response is None:
+                response = func(self, request, *args, **kwargs)
+
+            # Set relevant headers on the response if they don't already exist
+            # and if the request method is safe.
+            if request.method in ('GET', 'HEAD'):
+                if last_modified and not response.has_header('Last-Modified'):
+                    response['Last-Modified'] = http_date(last_modified)
+                if etag:
+                    response.setdefault('ETag', etag)
+
+            return response
+
         return wrapper
     return decorator
 
 
 # Shortcut decorators for common cases based on ETag or Last-Modified only
-def etag(etag_func):
-    return condition(etag_func=etag_func)
+def etag(etag_func, use_self=False):
+    return condition(etag_func=etag_func, use_self=use_self)
 
 
-def last_modified(last_modified_func):
-    return condition(last_modified_func=last_modified_func)
+def last_modified(last_modified_func, use_self=False):
+    return condition(last_modified_func=last_modified_func, use_self=use_self)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,6 +2,9 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from tests.views import (
+    builtin_etag_kwargs_view,
+    builtin_etag_view,
+    builtin_last_modified_view,
     ETagApiView,
     EtagFromKwargsViewSet,
     EtagViewSet,
@@ -20,15 +23,26 @@ router.register("etag-kwargs", EtagFromKwargsViewSet, basename="etag-kwargs")
 
 urlpatterns = [
     path(
-        "^api-view/no-condition/$",
+        "api-view/no-condition/",
         NoConditionApiView.as_view(),
         name="api-view-no-condition",
     ),
     path(
-        "^api-view/last-modified/$",
+        "api-view/last-modified/",
         LastModifiedApiView.as_view(),
         name="api-view-last-modified",
     ),
-    path("^api-view/etag/$", ETagApiView.as_view(), name="api-view-etag"),
-    path("^view-set/", include(router.urls)),
+    path("api-view/etag/", ETagApiView.as_view(), name="api-view-etag"),
+    path(
+        "builtin/last-modified/",
+        builtin_last_modified_view,
+        name="builtin-view-last-modified"
+    ),
+    path("builtin/etag/", builtin_etag_view, name="builtin-view-etag"),
+    path(
+        "builtin/etag/<pk>/",
+        builtin_etag_kwargs_view,
+        name="builtin-view-etag-kwargs",
+    ),
+    path("view-set/", include(router.urls)),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,21 +1,42 @@
 from datetime import datetime
 
+from django.http import JsonResponse
 from rest_framework import views, viewsets
 from rest_framework.response import Response
 
+from django.views.decorators.http import (
+    etag as builtin_etag,
+    last_modified as builtin_last_modified,
+)
 from rest_framework_condition import etag, last_modified
 
 
-def my_last_modified(request, *args, **kwargs):
+def my_last_modified(self, request, *args, **kwargs):
     return datetime(2019, 1, 1)
 
 
-def my_etag(request, *args, **kwargs):
+def my_etag(self, request, *args, **kwargs):
     return 'hash123'
 
 
-def etag_from_kwargs(request, *args, **kwargs):
+def etag_from_kwargs(self, request, *args, **kwargs):
     return 'hash-{}'.format(kwargs['pk'])
+
+
+@builtin_last_modified(lambda request: my_last_modified(None, request))
+def builtin_last_modified_view(request):
+    return JsonResponse({'data': '2019'})
+
+
+@builtin_etag(lambda request: my_etag(None, request))
+def builtin_etag_view(request):
+    return JsonResponse({'data': 'etag'})
+
+
+@builtin_etag(
+    lambda request, **kwargs: etag_from_kwargs(None, request, **kwargs))
+def builtin_etag_kwargs_view(request, pk):
+    return JsonResponse({'data': 'etag', 'pk': pk})
 
 
 class NoConditionApiView(views.APIView):
@@ -24,13 +45,13 @@ class NoConditionApiView(views.APIView):
 
 
 class LastModifiedApiView(views.APIView):
-    @last_modified(my_last_modified)
+    @last_modified(my_last_modified, use_self=True)
     def get(self, request):
         return Response({'data': '2019'})
 
 
 class ETagApiView(views.APIView):
-    @etag(my_etag)
+    @etag(my_etag, use_self=True)
     def get(self, request):
         return Response({'data': 'etag'})
 
@@ -44,26 +65,26 @@ class NoConditionViewSet(viewsets.ViewSet):
 
 
 class LastModifiedViewSet(viewsets.ViewSet):
-    @last_modified(my_last_modified)
+    @last_modified(my_last_modified, use_self=True)
     def list(self, request):
         return Response({'data': '2019'})
 
-    @last_modified(my_last_modified)
+    @last_modified(my_last_modified, use_self=True)
     def retrieve(self, request, pk=None):
         return Response({'data': '2019', 'pk': pk})
 
 
 class EtagViewSet(viewsets.ViewSet):
-    @etag(my_etag)
+    @etag(my_etag, use_self=True)
     def list(self, request):
         return Response({'data': 'etag'})
 
-    @etag(my_etag)
+    @etag(my_etag, use_self=True)
     def retrieve(self, request, pk=None):
         return Response({'data': 'etag', 'pk': pk})
 
 
 class EtagFromKwargsViewSet(viewsets.ViewSet):
-    @etag(etag_from_kwargs)
+    @etag(etag_from_kwargs, use_self=True)
     def retrieve(self, request, pk=None):
         return Response({'data': 'etag', 'pk': pk})

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
     pytest-cov
 commands =
     # NOTE: you can run any command line tool here - not just tests
-    pytest --cov=rest_framework_condition/
+    pytest --cov=rest_framework_condition/ {posargs}


### PR DESCRIPTION
While the existing implementation is simple it: creates a decorated function per request, calls it, and then will discard it. Since the
functionality is straightforward and also encapsulated fairly well in Django, this PR modifies the decorator to copy the original Django decorator, and calls the same helper functions where possible.

Because the functionality is no longer simply wrapping Django's internal implementation, but is still mostly the same, there have been tests added to compare the requests generated by Django vs requests generated by Django Request Framework/this library.

Finally, in order to be less confusing to library writers the call signature of `etag_func` and `last_modified_func` has been updated to match Django Request Framework and will pass a DRF Request object instead
of Django's native Request object:

```python
# from the original signature
def original_etag_func(wsgi_request, *args, **kwargs): pass

# to the updated signature
def updated_etag_func(drf_self, drf_request, *args, **kwargs): pass
```

In order to ease the transition between the two signatures, there has been a flag "use_self" added to the decorators, and a warning will be emitted if use_self has not been set to True.